### PR TITLE
feat: add translation for swedish to english

### DIFF
--- a/prevodach.js
+++ b/prevodach.js
@@ -3,7 +3,7 @@ const { v4: uuidv4 } = require('uuid');
 
 // PLEASE DONT STEAL THIS
 // GCP SECRET VALUE ?
-var subscriptionKey = process.env['translator-key'];
+const { translatorKey } = require('config.json');
 var endpoint = 'https://api.cognitive.microsofttranslator.com';
 
 module.exports.swedishToEnglish = async (message) => {
@@ -19,7 +19,7 @@ async function translate(message, targetLanguages) {
     url: '/translate',
     method: 'post',
     headers: {
-      'Ocp-Apim-Subscription-Key': subscriptionKey,
+      'Ocp-Apim-Subscription-Key': translatorKey,
       // Add your location, also known as region. The default is global.
       // This is required if using a Cognitive Services resource.
       'Ocp-Apim-Subscription-Region': 'westeurope',

--- a/prevodach.js
+++ b/prevodach.js
@@ -6,12 +6,12 @@ const { v4: uuidv4 } = require('uuid');
 var subscriptionKey = process.env['translator-key'];
 var endpoint = 'https://api.cognitive.microsofttranslator.com';
 
-async function swedishToEnglish(message) {
+module.exports.swedishToEnglish = async (message) => {
   const translation = await translate(message, ['en']);
 
   // return only english FOR NOW
   return translation[0].translations.find((t) => t.to == 'en');
-}
+};
 
 async function translate(message, targetLanguages) {
   const request = {
@@ -46,7 +46,3 @@ async function translate(message, targetLanguages) {
     console.error(e);
   }
 }
-
-module.exports = {
-  swedishToEnglish,
-};

--- a/prevodach.js
+++ b/prevodach.js
@@ -3,7 +3,7 @@ const { v4: uuidv4 } = require('uuid');
 
 // PLEASE DONT STEAL THIS
 // GCP SECRET VALUE ?
-const { translatorKey } = require('./config.json');
+const { swekey } = require('./config.json');
 var endpoint = 'https://api.cognitive.microsofttranslator.com';
 
 module.exports.swedishToEnglish = async (message) => {

--- a/prevodach.js
+++ b/prevodach.js
@@ -1,0 +1,48 @@
+const axios = require('axios').default;
+const { v4: uuidv4 } = require('uuid');
+
+// PLEASE DONT STEAL THIS
+// GCP SECRET VALUE ?
+var subscriptionKey = process.env[translatorKey];
+var endpoint = 'https://api.cognitive.microsofttranslator.com';
+
+export async function swedishToEnglish(message) {
+  const translation = await translate(message, ['en']);
+
+  // return only english FOR NOW
+  return translation[0].translations.find((t) => t.to == 'en');
+}
+
+async function translate(message, targetLanguages) {
+  const request = {
+    baseURL: endpoint,
+    url: '/translate',
+    method: 'post',
+    headers: {
+      'Ocp-Apim-Subscription-Key': subscriptionKey,
+      // Add your location, also known as region. The default is global.
+      // This is required if using a Cognitive Services resource.
+      'Ocp-Apim-Subscription-Region': 'westeurope',
+      'Content-type': 'application/json',
+      'X-ClientTraceId': uuidv4().toString(),
+    },
+    params: {
+      'api-version': '3.0',
+      'to': targetLanguages,
+    },
+    data: [
+      {
+        text: message,
+      },
+    ],
+    responseType: 'json',
+  };
+
+  try {
+    const response = await axios.post(request);
+    return response.data;
+  } catch (e) {
+    // YELL IN THE CONSOLE FOR NO GOOD REASON
+    console.error(e);
+  }
+}

--- a/prevodach.js
+++ b/prevodach.js
@@ -6,7 +6,7 @@ const { v4: uuidv4 } = require('uuid');
 var subscriptionKey = process.env['translator-key'];
 var endpoint = 'https://api.cognitive.microsofttranslator.com';
 
-export async function swedishToEnglish(message) {
+async function swedishToEnglish(message) {
   const translation = await translate(message, ['en']);
 
   // return only english FOR NOW
@@ -46,3 +46,7 @@ async function translate(message, targetLanguages) {
     console.error(e);
   }
 }
+
+module.exports = {
+  swedishToEnglish,
+};

--- a/prevodach.js
+++ b/prevodach.js
@@ -3,7 +3,7 @@ const { v4: uuidv4 } = require('uuid');
 
 // PLEASE DONT STEAL THIS
 // GCP SECRET VALUE ?
-const { translatorKey } = require('config.json');
+const { translatorKey } = require('./config.json');
 var endpoint = 'https://api.cognitive.microsofttranslator.com';
 
 module.exports.swedishToEnglish = async (message) => {

--- a/prevodach.js
+++ b/prevodach.js
@@ -3,7 +3,7 @@ const { v4: uuidv4 } = require('uuid');
 
 // PLEASE DONT STEAL THIS
 // GCP SECRET VALUE ?
-var subscriptionKey = process.env[translatorKey];
+var subscriptionKey = process.env['translator-key'];
 var endpoint = 'https://api.cognitive.microsofttranslator.com';
 
 export async function swedishToEnglish(message) {


### PR DESCRIPTION
Hook into https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-overview

We get 2M characters per month for free

It auto-detects the language and we can set it to translate to multiple languages

Need to figure out how to set an env variable in GCP For the secret Key i dont want it checked in a public repo